### PR TITLE
Correct fan_speed typo for andor neo camera

### DIFF
--- a/lantz/drivers/andor/neo.py
+++ b/lantz/drivers/andor/neo.py
@@ -57,7 +57,7 @@ class Neo(Andor):
         self.setenumstring("PixelReadoutRate", value)
 
     @Feat(None)
-    def fan_peed(self, value=1):
+    def fan_speed(self, value=1):
         """Fan speed.
         """
         self.setenumerated("FanSpeed", value)

--- a/lantz/drivers/legacy/andor/neo.py
+++ b/lantz/drivers/legacy/andor/neo.py
@@ -57,7 +57,7 @@ class Neo(Andor):
         self.setenumstring("PixelReadoutRate", value)
 
     @Feat(None)
-    def fan_peed(self, value=1):
+    def fan_speed(self, value=1):
         """Fan speed.
         """
         self.setenumerated("FanSpeed", value)


### PR DESCRIPTION
Originally opened on the old, unmaintained repo, thanks @aquilesC 